### PR TITLE
Version 2.0.0!

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,30 @@ Throw your rose-tinted [lenses](https://medium.com/javascript-inside/an-introduc
 
 # What
 
-Patchinko exposes 3 functions: `patch`, `scope`, & `ps`.
+Patchinko exposes 3 functions: `P`, `S`, & `PS`.
 
-`patch` is like `Object.assign` - given `patch(target, input1, input2, etc)`, it consumes inputs left to right and copies their properties onto the supplied target.
+`P` is like `Object.assign`: given `P(target, input1, input2, etc)`, it consumes inputs left to right and copies their properties onto the supplied target
 
-*except that*
+*…except that…*
 
-If any target properties are instances of `scope(function)`, it will supply the scoped function with the target property for that key, and assign the result back to the target.
+If any target properties are instances of `S(function)`, it will supply the scoped function with the target property for that key, and assign the result back to the target; if any target properties are `D`, it will delete the property of the same key on the target.
 
-`ps([ target, ] input)` is a composition of `patch` & `scope`, for when you need to patch recursively. If you supply a `target`, the original value will be left untouched (useful for immutable patching).
+`PS([ target, ] input)` is a composition of `P` & `S`, for when you need to patch recursively. If you supply a `target`, the original value will be left untouched (useful for immutable patching).
 
 # How
 
 The kitchen sink example:
 
 ```js
-const {patch : p, scope : s, ps} = require('patchinko')
+const {P, S, PS, D} = require('patchinko')
 
 // Some arbitrary structure
 const thing = {
   foo: 'bar',
 
   fizz: 'buzz',
+
+  bish: 'bash',
 
   utils: {
     mean: (...set) =>
@@ -42,16 +44,18 @@ const thing = {
     deep: {
       structure: ['lol']
     },
-    with: ['an', 'array', 'tacked']
+    with: ['a', 'list', 'tacked', 'on']
   }
 }
 
 // A deep patch
-p(thing, {
-  foo: 'baz', // Change the value of foo
+P(thing, {
+  foo: 'baz', // Change the value of `foo`
 
-  utils: ps({ // We want to patch a level deeper
-    fibonacci: s(function closure(definition){ // Memoize fibonacci
+  bish: D, // Delete property `bish`
+
+  utils: PS({ // We want to patch a level deeper
+    fibonacci: S(function closure(definition){ // Memoize `fibonacci`
       var cache = {}
 
       return function override(x){
@@ -64,13 +68,13 @@ p(thing, {
     })
   }),
 
-  stupidly: ps({
-    deep: ps({
-      structure: s(structure =>
+  stupidly: PS({
+    deep: PS({
+      structure: S(structure =>
         structure.concat('roflmao') // Why not
       )
     }),
-    with: ps(
+    with: PS(
       [],
       {1: 'copy'}
     ) // ['a', 'copy', 'tacked'], the original array is left untouched
@@ -84,11 +88,8 @@ Observe that:
 * `utils.fibonacci` can safely be decorated (again, the rest of `utils` is unaffected)
 * `stupidly.deep.structure` can be modified, keeping its identity
 
-`stupidly.deep.stucture` & `utils.fibonacci` show that any kind of structure can be modified or replaced at any kind of depth: `patch` is geared towards the common case of objects, but `scope` can deal with any type in whatever way necessary. You get closures for free so gnarly patch logic can be isolated at the point where it makes the most sense.
+`stupidly.deep.stucture` & `utils.fibonacci` show that any kind of structure can be modified or replaced at any kind of depth: `P` is geared towards the common case of objects, but `S` can deal with any type in whatever way necessary. You get closures for free so gnarly patch logic can be isolated at the point where it makes the most sense.
 
-```JS
-
-````
 
 # Why
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ P(thing, {
     with: PS(
       [],
       {1: 'copy'}
-    ) // ['a', 'copy', 'tacked'], the original array is left untouched
+    ) // ['a', 'copy', 'tacked', 'on'] - the original array is left untouched
   })
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,35 +1,40 @@
-function patch(target){
+function P(target){
   for(var i = 1; i < arguments.length; i++)
     for(var key in arguments[i])
       if(arguments[i].hasOwnProperty(key))
-        target[key] = (
-          arguments[i][key] instanceof scope
+        arguments[i][key] == D
+        ? delete target[key]
+        : target[key] =
+          arguments[i][key] instanceof S
           ? arguments[i][key].apply(target[key])
           : arguments[i][key]
-        )
 
   return target
 }
 
-function scope(closure){
-  if(!(this instanceof scope))
-    return new scope(closure)
+function S(closure){
+  if(!(this instanceof S))
+    return new S(closure)
 
   this.apply = function(definition){
     return closure(definition)
   }
 }
 
-function ps(target, input){
-  return arguments.length === 2
-  ? new scope(function(definition){
-    return patch(target, definition, input)
-  })
-  : new scope(function(definition){
-    return patch(definition, target) // `target` really is `input` in that case
-  })
+function PS(target, input){
+  return new S(
+    arguments.length === 2
+    ? function(definition){
+      return P(target, definition, input)
+    }
+    : function(definition){
+      return P(definition, target)
+    }
+  )
 }
 
+function D(){}
+
 try {
-  module.exports = {patch: patch, scope: scope, ps: ps}
+  module.exports = {P: P, S: S, PS: PS, D: D}
 } catch(e) {}


### PR DESCRIPTION
* Fixes #6. Properties on targets can now be deleted declaratively.
* API is now `P`, `S`, `PS`, `D` (was `patch`, `scope`, `ps`). Terse capital initials are more consistently identifiable, at a skim, as directives in arbitrary code structures.