### PR TITLE
Assign patch when PSing to undefined target props

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function PS(target, input){
       return P(target, definition, input)
     }
     : function(definition){
-      return P(definition, target)
+      return definition == void 0 ? target : P(definition, target)
     }
   )
 }


### PR DESCRIPTION
```js
var attrs = {
  value: 'hello'
}

P(attrs, {
  disabled: true,
  style: PS({ // <= can't assign property 'opacity' to non-existent 'style' prop on target
    opacity: .5
  })
})
```
  